### PR TITLE
Added base Topic type to Bentley catalog

### DIFF
--- a/dtd/technicalContent/catalog.xml
+++ b/dtd/technicalContent/catalog.xml
@@ -6,6 +6,9 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 <!--DITA Technical Content modules-->
+   <public publicId="-//BENTLEY//DTD DITA 1.3 Topic//EN" uri="dtd/topic.dtd"/>
+   <public publicId="-//BENTLEY//DTD DITA 1.x Topic//EN" uri="dtd/topic.dtd"/>
+   <public publicId="-//BENTLEY//DTD DITA Topic//EN" uri="dtd/topic.dtd"/>
         
    <public publicId="-//BENTLEY//DTD DITA 1.3 Concept//EN" uri="dtd/concept.dtd"/>
    <public publicId="-//BENTLEY//DTD DITA 1.x Concept//EN" uri="dtd/concept.dtd"/>

--- a/dtd/technicalContent/dtd/topic.dtd
+++ b/dtd/technicalContent/dtd/topic.dtd
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
+<!-- OASIS Standard                                           -->
+<!-- 16 January 2018                                           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!--  MODULE:    DITA Topic                                        -->
+<!--  VERSION:   1.3                                               -->
+<!--  DATE:      March 2014                                        -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!--                    PUBLIC DOCUMENT TYPE DEFINITION            -->
+<!--                    TYPICAL INVOCATION                         -->
+<!--                                                               -->
+<!--  Refer to this file by the following public identifier or an  -->
+<!--       appropriate system identifier                           -->
+<!--                                                               -->
+<!-- PUBLIC "-//BENTLEY//DTD DITA Topic//EN"                         -->
+<!-- The public ID above refers to the latest version of this DTD. -->
+<!--      To refer to this specific version, you may use this value: -->
+<!-- PUBLIC "-//BENTLEY//DTD DITA 1.3 Topic//EN"                          -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Darwin Information Typing Architecture (DITA)     -->
+<!--                                                               -->
+<!-- PURPOSE:    DTD to describe DITA Topics                       -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--             March 2001                                        -->
+<!--                                                               -->
+<!--             (C) Copyright OASIS Open 2005, 2009.              -->
+<!--             (C) Copyright IBM Corporation 2001, 2004.         -->
+<!--             All Rights Reserved.                              -->
+<!--                                                               -->
+<!--  UPDATES:                                                     -->
+<!--    2006.06.07 RDA: Added indexing domain                      -->
+<!--    2006.06.21 RDA: Added props attribute extensions           -->
+<!--    2007.12.01 EK:  Reformatted DTD modules for DITA 1.2       -->
+<!--    2008.02.12 RDA: Modify imbeds to use specific 1.2 version  -->
+<!--    2008.04.15 RDA: Added hazard domain                        -->
+<!--    2024.01.18 JTC: Created shell for Bentley                  -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--              TOPIC ENTITY DECLARATIONS                        -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--             DOMAIN CONSTRAINT INTEGRATION                     -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--             DOMAIN ENTITY DECLARATIONS                        -->
+<!-- ============================================================= -->
+
+<!-- JTC: use OASIS entities where not changed -->
+<!ENTITY % abbrev-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Abbreviated Form Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/abbreviateDomain.ent"
+>%abbrev-d-dec;
+
+<!ENTITY % equation-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Equation Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/equationDomain.ent"
+>%equation-d-dec;
+
+<!ENTITY % hazard-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Hazard Statement Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/hazardstatementDomain.ent"
+>%hazard-d-dec;
+
+<!ENTITY % indexing-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Indexing Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/indexingDomain.ent"
+>%indexing-d-dec;
+
+<!ENTITY % markup-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Markup Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/markupDomain.ent"
+>%markup-d-dec;
+
+<!ENTITY % mathml-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 MathML Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/mathmlDomain.ent"
+>%mathml-d-dec;
+
+<!ENTITY % relmgmt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Release Management Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/releaseManagementDomain.ent"
+>%relmgmt-d-dec;
+
+<!ENTITY % sw-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Software Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/softwareDomain.ent"
+>%sw-d-dec;
+
+<!ENTITY % svg-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 SVG Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/svgDomain.ent"
+>%svg-d-dec;
+
+<!ENTITY % ut-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Utilities Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/utilitiesDomain.ent"
+>%ut-d-dec;
+
+<!ENTITY % xml-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 XML Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/xmlDomain.ent"
+>%xml-d-dec;
+
+<!-- JTC: Use BENTLEY entities for specialized domains -->
+<!ENTITY % hi-d-dec
+  PUBLIC "-//BENTLEY//ENTITIES DITA 1.3 Highlight Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/highlightDomain.ent"
+>%hi-d-dec;
+
+<!ENTITY % pr-d-dec
+  PUBLIC "-//BENTLEY//ENTITIES DITA 1.3 Programming Domain//EN"
+         "programmingDomain.ent"
+>%pr-d-dec;
+
+<!ENTITY % ui-d-dec
+  PUBLIC "-//BENTLEY//ENTITIES DITA 1.3 User Interface Domain//EN"
+         "uiDomain.ent"
+>%ui-d-dec;
+
+<!-- ============================================================= -->
+<!--             DOMAIN ATTRIBUTES DECLARATIONS                    -->
+<!-- ============================================================= -->
+
+<!ENTITY % deliveryTargetAtt-d-dec
+  PUBLIC "-//OASIS//ENTITIES DITA 1.3 Delivery Target Attribute Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/deliveryTargetAttDomain.ent"
+>%deliveryTargetAtt-d-dec;
+
+<!-- ============================================================= -->
+<!--                    DOMAIN EXTENSIONS                          -->
+<!-- ============================================================= -->
+<!--                    One for each extended base element, with
+                        the name of the domain(s) in which the
+                        extension was declared                     -->
+
+<!ENTITY % index-base   "index-base |
+                         %indexing-d-index-base;
+                        ">
+<!ENTITY % note         "note |
+                         %hazard-d-note;
+                        ">
+<!ENTITY % ph           "ph |
+                         %hi-d-ph; |
+                         %pr-d-ph; |
+                         %sw-d-ph; |
+                         %ui-d-ph; |
+                         %equation-d-ph;
+                        ">
+<!ENTITY % fig          "fig |
+                         %ut-d-fig; |
+                         %pr-d-fig; |
+                         %equation-d-fig;
+                        ">
+<!ENTITY % data         "data |
+                         %ut-d-data;
+                        ">
+<!ENTITY % term         "term |
+                         %abbrev-d-term;
+                        ">
+<!ENTITY % keyword      "keyword |
+                         %markup-d-keyword; |
+                         %pr-d-keyword; |
+                         %sw-d-keyword; |
+                         %ui-d-keyword; |
+                         %xml-d-keyword;
+                        ">
+<!ENTITY % pre          "pre |
+                         %pr-d-pre; |
+                         %sw-d-pre; |
+                         %ui-d-pre;
+                        ">
+<!ENTITY % dl           "dl |
+                         %pr-d-dl;
+                        ">
+<!ENTITY % metadata     "metadata |
+                         %relmgmt-d-metadata;
+                        ">
+<!ENTITY % foreign      "foreign |
+                         %svg-d-foreign; |
+                         %mathml-d-foreign;
+                        ">
+<!ENTITY % div          "div |
+                         %equation-d-div;
+                        ">
+<!-- 2024-01-18 JTC: Added Bentley domain specializations -->
+<!ENTITY % figgroup     "figgroup |
+                         %pr-d-figgroup;
+                         ">
+                         
+<!-- ============================================================= -->
+<!--                    DOMAIN ATTRIBUTE EXTENSIONS                -->
+<!-- ============================================================= -->
+
+<!ENTITY % props-attribute-extensions
+  "%deliveryTargetAtt-d-attribute;"
+>
+<!ENTITY % base-attribute-extensions
+  ""
+>
+
+<!-- ============================================================= -->
+<!--                    TOPIC NESTING OVERRIDE                     -->
+<!-- ============================================================= -->
+
+<!ENTITY % topic-info-types
+              "topic"
+>
+
+<!-- ============================================================= -->
+<!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
+<!-- ============================================================= -->
+
+<!ENTITY included-domains
+                          "&abbrev-d-att;
+                           &deliveryTargetAtt-d-att;
+                           &equation-d-att;
+                           &hazard-d-att;
+                           &hi-d-att;
+                           &indexing-d-att;
+                           &markup-d-att;
+                           &mathml-d-att;
+                           &pr-d-att;
+                           &relmgmt-d-att;
+                           &sw-d-att;
+                           &svg-d-att;
+                           &ui-d-att;
+                           &ut-d-att;
+                           &xml-d-att;
+  "
+>
+
+<!-- ============================================================= -->
+<!--                    CONTENT CONSTRAINT INTEGRATION             -->
+<!-- ============================================================= -->
+
+<!-- ============================================================= -->
+<!--                    TOPIC ELEMENT INTEGRATION                  -->
+<!-- ============================================================= -->
+
+<!ENTITY % topic-type
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Topic//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/topic.mod"
+>%topic-type;
+
+<!-- ============================================================= -->
+<!--                    DOMAIN ELEMENT INTEGRATION                 -->
+<!-- ============================================================= -->
+
+<!ENTITY % abbrev-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Abbreviated Form Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/abbreviateDomain.mod"
+>%abbrev-d-def;
+
+<!ENTITY % equation-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Equation Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/equationDomain.mod"
+>%equation-d-def;
+
+<!ENTITY % hazard-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Hazard Statement Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/hazardstatementDomain.mod"
+>%hazard-d-def;
+
+<!ENTITY % indexing-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Indexing Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/indexingDomain.mod"
+>%indexing-d-def;
+
+<!ENTITY % markup-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Markup Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/markupDomain.mod"
+>%markup-d-def;
+
+<!ENTITY % mathml-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 MathML Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/mathmlDomain.mod"
+>%mathml-d-def;
+
+<!ENTITY % relmgmt-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Release Management Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/releaseManagementDomain.mod"
+>%relmgmt-d-def;
+
+<!ENTITY % sw-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Software Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/softwareDomain.mod"
+>%sw-d-def;
+
+<!ENTITY % svg-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 SVG Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/svgDomain.mod"
+>%svg-d-def;
+
+<!ENTITY % ut-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 Utilities Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/base/dtd/utilitiesDomain.mod"
+>%ut-d-def;
+
+<!ENTITY % xml-d-def
+  PUBLIC "-//OASIS//ELEMENTS DITA 1.3 XML Domain//EN"
+         "../../../../org.oasis-open.dita.v1_3/dtd/technicalContent/dtd/xmlDomain.mod"
+>%xml-d-def;
+
+<!-- JTC: Use BENTLEY speicalized domain elements -->
+<!ENTITY % hi-d-def
+  PUBLIC "-//BENTLEY//ELEMENTS DITA 1.3 Highlight Domain//EN"
+         "../../base/dtd/highlightDomain.mod"
+>%hi-d-def;
+
+<!ENTITY % pr-d-def
+  PUBLIC "-//BENTLEY//ELEMENTS DITA 1.3 Programming Domain//EN"
+         "programmingDomain.mod"
+>%pr-d-def;
+
+<!ENTITY % ui-d-def
+  PUBLIC "-//BENTLEY//ELEMENTS DITA 1.3 User Interface Domain//EN"
+         "uiDomain.mod"
+>%ui-d-def;
+<!-- ================= End of DITA Topic Shell ================= -->

--- a/rng/technicalContent/catalog.xml
+++ b/rng/technicalContent/catalog.xml
@@ -6,7 +6,11 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 -->
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 
-   <group><!-- System ID (URL) catalog entries -->
+  <group><!-- System ID (URL) catalog entries -->
+      <system systemId="urn:bentley:names:tc:dita:rng:topic.rng:1.3" uri="rng/topic.rng"/>
+      <system systemId="urn:bentley:names:tc:dita:rng:topic.rng:1.x" uri="rng/topic.rng"/>
+      <system systemId="urn:bentley:names:tc:dita:rng:topic.rng" uri="rng/topic.rng"/>
+                
       <system systemId="urn:bentley:names:tc:dita:rng:concept.rng:1.3"
               uri="rng/concept.rng"/>
       <system systemId="urn:bentley:names:tc:dita:rng:concept.rng:1.x"
@@ -123,6 +127,9 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
               uri="rng/verificationMod.rng"/>
    </group>
    <group><!-- Public ID (URN) catalog entries -->
+      <uri name="urn:bentley:names:tc:dita:rng:topic.rng:1.3" uri="rng/topic.rng"/>
+      <uri name="urn:bentley:names:tc:dita:rng:topic.rng:1.x" uri="rng/topic.rng"/>
+      <uri name="urn:bentley:names:tc:dita:rng:topic.rng" uri="rng/topic.rng"/>
            
       <uri name="urn:bentley:names:tc:dita:rng:concept.rng:1.3"
            uri="rng/concept.rng"/>

--- a/rng/technicalContent/rng/topic.rng
+++ b/rng/technicalContent/rng/topic.rng
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:checkShell.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="urn:oasis:names:tc:dita:rng:vocabularyModuleDesc.rng"
+                         schematypens="http://relaxng.org/ns/structure/1.0"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:dita="http://dita.oasis-open.org/architecture/2005/" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+  xmlns:svg="http://www.w3.org/2000/svg">
+  <moduleDesc xmlns="http://dita.oasis-open.org/architecture/2005/">
+    <moduleTitle>DITA Topic Shell</moduleTitle>
+    <headerComment xml:space="preserve">
+=============================================================
+                   HEADER                                    
+=============================================================
+Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02
+OASIS Standard
+16 January 2018 
+Copyright (c) OASIS Open 2018. All rights reserved. 
+Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html
+
+============================================================
+ MODULE:    DITA Topic                                  
+ VERSION:   1.3                                              
+ DATE:      March 2014                                    
+                                                             
+=============================================================
+
+=============================================================
+                   PUBLIC DOCUMENT TYPE DEFINITION           
+                   TYPICAL INVOCATION                        
+                                                             
+ Refer to this file by the following public identifier or an 
+      appropriate system identifier 
+      
+PUBLIC "-//BENTLEY//DTD DITA Topic//EN"
+
+The public ID above refers to the latest version of this DTD.
+     To refer to this specific version, you may use this value:
+
+PUBLIC "-//BENTLEY//DTD DITA 1.3 Topic//EN"                         
+
+=============================================================
+SYSTEM:     Darwin Information Typing Architecture (DITA)    
+                                                             
+PURPOSE:    DTD to describe DITA Topics                      
+                                                             
+ORIGINAL CREATION DATE:                                      
+            March 2001                                       
+                                                             
+            (C) Copyright OASIS Open 2005, 2009.             
+            (C) Copyright IBM Corporation 2001, 2004.        
+            All Rights Reserved.                             
+                                                             
+ UPDATES:                                                    
+   2006.06.07 RDA: Added indexing domain                     
+   2006.06.21 RDA: Added props attribute extensions          
+   2007.12.01 EK:  Reformatted DTD modules for DITA 1.2       
+   2008.02.12 RDA: Modify imbeds to use specific 1.2 version 
+   2008.04.15 RDA: Added hazard domain                       
+   2024.01.18 JTC: Created shell for Bentley
+=============================================================
+</headerComment>
+    <moduleMetadata>
+      <moduleType>topicshell</moduleType>
+      <moduleShortName>topic</moduleShortName>
+      <shellPublicIds>
+        <dtdShell>-//BENTLEY//DTD DITA<var presep=" " name="ditaver"/> Topic//EN</dtdShell>
+        <rncShell>urn:bentley:names:tc:dita:rnc:topic.rnc<var presep=":" name="ditaver"/></rncShell>
+        <rngShell>urn:bentley:names:tc:dita:rng:topic.rng<var presep=":" name="ditaver"/></rngShell>
+        <xsdShell>urn:bentley:names:tc:dita:xsd:topic.xsd<var presep=":" name="ditaver"/></xsdShell>
+      </shellPublicIds>
+    </moduleMetadata>
+  </moduleDesc>
+  <div>
+    <a:documentation>ROOT ELEMENT</a:documentation>
+    <start>
+      <ref name="topic.element"/>
+    </start>
+  </div>
+  <div>
+    <a:documentation>DOMAINS ATTRIBUTE</a:documentation>
+    <define name="domains-att">
+      <optional>
+        <attribute name="domains"
+          a:defaultValue="(topic abbrev-d)
+                         (topic equation-d)
+                         (topic hazard-d)
+                         (topic hi-d)
+                         (topic indexing-d)
+                         (topic markup-d xml-d)
+                         (topic markup-d)
+                         (topic mathml-d)
+                         (topic pr-d)
+                         (topic relmgmt-d)
+                         (topic svg-d)
+                         (topic sw-d)
+                         (topic ui-d)
+                         (topic ut-d)
+                         a(props deliveryTarget)"
+        />
+      </optional>
+    </define>
+  </div>
+
+  <div>
+    <a:documentation>INCLUDE MODULES</a:documentation>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/base/rng/topicMod.rng">
+      <define name="topic-info-types">
+        <ref name="topic.element"/>
+      </define>
+    </include>  
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/abbreviateDomain.rng"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/base/rng/deliveryTargetAttDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/equationDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/base/rng/hazardstatementDomain.rng"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/base/rng/indexingDomain.rng"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/markupDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/mathmlDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/releaseManagementDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/softwareDomain.rng"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/svgDomain.rng" dita:since="1.3"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/base/rng/utilitiesDomain.rng"/>
+    <include href="../../../../org.oasis-open.dita.v1_3/rng/technicalContent/rng/xmlDomain.rng" dita:since="1.3"/>
+    
+    <!-- JTC: Use BENTLEY speicalized domain elements -->
+    <include href="../../base/rng/highlightDomain.rng"/>
+    <include href="programmingDomain.rng"/>
+    <include href="uiDomain.rng"/>
+  </div>
+  <div>
+    <a:documentation>ID-DEFINING-ELEMENT OVERRIDES</a:documentation>
+    <define name="any">
+      <zeroOrMore>
+        <choice>
+          <ref name="idElements"/>
+          <element>
+            <anyName>
+              <except>
+                <name>topic</name>
+                <nsName ns="http://www.w3.org/2000/svg"/>
+                <nsName ns="http://www.w3.org/1998/Math/MathML"/>
+              </except>
+            </anyName>
+            <zeroOrMore>
+              <attribute>
+                <anyName/>
+              </attribute>
+            </zeroOrMore>
+            <ref name="any"/>
+          </element>
+          <text/>
+        </choice>
+      </zeroOrMore>
+    </define>
+  </div>
+</grammar>

--- a/samples/dtd/base_topic.dita
+++ b/samples/dtd/base_topic.dita
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//BENTLEY//DTD DITA Topic//EN" "topic.dtd">
+<topic id="base_topic">
+    <title>Base Topic</title>
+    <shortdesc>This topic uses the Bentley Topic DocType.</shortdesc>
+    <body>
+        <section>
+            <title>Highlighting Domain</title>
+            
+            <p>Now <em>this</em> is some emphasis!</p>
+            
+        </section>
+        <section>
+            <title>UI Domain</title>
+            <p>Press  <kbd>Ctrl+O</kbd> to open a new document.</p>
+        </section>
+        <section id="section_ljy_s5l_d1c">
+            <title>Programming Domain</title>
+            <syntaxdiagram id="syntaxdiagram_mjy_s5l_d1c">
+                <keyin>
+                    <kwd>Place Fence</kwd>
+                    <kwdchoice>
+                        <kwd>Block</kwd>
+                        <kwd>Circle</kwd>
+                    </kwdchoice>
+                </keyin>
+            </syntaxdiagram>
+        </section>
+    </body>
+</topic>

--- a/samples/dtd/c-concept.xml
+++ b/samples/dtd/c-concept.xml
@@ -24,62 +24,116 @@
   <section>
    <title>Equation and Math Domains</title>
 
-   <p>A legacy inline equation with text content: <mathph>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></mathph></p>
-  <p>An inline equation: <equation-inline>
-   <mathml></mathml>
-  </equation-inline></p>
-  <equation>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <eqsymbols>
-    <eqsymbol>
-     <symname>A</symname>
-     <symdesc>Long side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>B</symname>
-     <symdesc>Short side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>C</symname>
-     <symdesc>Hypotenuse of triangle</symdesc>
-    </eqsymbol>
-   </eqsymbols>
-  </equation>
-   <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
-   <p>A legacy inline equation with MathML content: <mathph><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"
-			 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
-				<mml:msup> <mml:mi>a</mml:mi> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:msup> <mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math></mathph></p>
-   <p>An <codeph>&lt;equation-block&gt;</codeph> element containing MathML markup:</p>
-  <equation-block id="equation-block_p2c_xxd_cjb">
-   <mathml>
-    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
-				<mml:msup> <mml:mi>a</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:msup>
-				<mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi> <mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math>
-   </mathml>
-  </equation-block>
+      <p>An <xmlelement>equation-inline</xmlelement> element with text content:
+                        <equation-inline>A<sup>2</sup> + B<sup>2</sup> =
+                    C<sup>2</sup></equation-inline></p>
+    <p>An <xmlelement>equation-figure</xmlelement> element with text content:</p>
+  <equation-figure>
+   <equation-block>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></equation-block>
+   <dl>
+    <dlentry>
+     <dt>A</dt>
+     <dd>Long side of triangle</dd>
+    </dlentry>
+       <dlentry>
+     <dt>B</dt>
+     <dd>Short side of triangle</dd>
+    </dlentry>
+       <dlentry>
+     <dt>C</dt>
+     <dd>Hypotenuse of triangle</dd>
+    </dlentry>
+   </dl>
+  </equation-figure>
+   
+      <p>An  <xmlelement>equation-inline</xmlelement> with MathML content: <equation-inline><mathml>
+                        <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+                            id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
+                            <m:msup>
+                                <m:mi>a</m:mi>
+                                <m:mn>2</m:mn>
+                            </m:msup>
+                            <m:msup>
+                                <m:mrow>
+                                    <m:mo>+</m:mo>
+                                    <m:mi>b</m:mi>
+                                </m:mrow>
+                                <m:mn>2</m:mn>
+                            </m:msup>
+                            <m:mo>=</m:mo>
+                            <m:msup>
+                                <m:mi>c</m:mi>
+                                <m:mn>2</m:mn>
+                            </m:msup>
+                        </m:math>
+                    </mathml></equation-inline></p>
+   <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+                    <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+
+      <equation-block>
+          <mathml>
+              <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true"><m:mi>x</m:mi><m:mo>=</m:mo><m:mfrac><m:mrow><m:mo>-</m:mo><m:mi>b</m:mi><m:mo>±</m:mo><m:msqrt><m:msup><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo>-</m:mo><m:mn>4</m:mn><m:mi>a</m:mi><m:mi>c</m:mi></m:msqrt></m:mrow><m:mrow><m:mn>2</m:mn><m:mi>a</m:mi></m:mrow></m:mfrac></m:math>    
+          </mathml>
+      </equation-block>
+      <p>An <xmlelement>equation-figure</xmlelement> containing MathML markup:</p>
+      <equation-figure>
+          <equation-block id="equation-block_p2c_xxd_cjb">
+              <mathml>
+                  <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
+                      <m:msup> <m:mi>a</m:mi>
+                          <m:mn>2</m:mn> </m:msup> <m:msup>
+                              <m:mrow> <m:mo>+</m:mo> <m:mi>b</m:mi> </m:mrow> <m:mn>2</m:mn> </m:msup>
+                      <m:mo>=</m:mo> <m:msup> <m:mi>c</m:mi> <m:mn>2</m:mn> </m:msup> 
+                  </m:math>
+              </mathml>
+          </equation-block>
+          <dl>
+              <dlentry>
+                  <dt><equation-inline><mathml><m:math><m:mi>A</m:mi></m:math></mathml></equation-inline></dt>
+                  <dd>Long side of triangle</dd>
+              </dlentry>
+              <dlentry>
+                  <dt><equation-inline><mathml><m:math><m:mi>B</m:mi></m:math></mathml></equation-inline></dt>
+                  <dd>Short side of triangle</dd>
+              </dlentry>
+              <dlentry>
+                  <dt><equation-inline><mathml><m:math><m:mi>C</m:mi></m:math></mathml></equation-inline></dt>
+                  <dd>Hypotenuse of triangle</dd>
+              </dlentry>
+          </dl>
+      </equation-figure>
   </section>
   <section>
    <title>Programming Domain</title>
-   <p></p>
-   
+   <p>A <xmlelement>keyin</xmlelement> element using a optional <xmlelement>kwdchoice</xmlelement> element:</p>   
   <syntaxdiagram>
    <keyin>
-    <kwd></kwd><kwdchoice>
-     <kwd></kwd>
+    <kwd>PLACE</kwd> <kwd>FENCE</kwd><kwdchoice>
+        <kwd>BLOCK</kwd>
+        <kwd>CIRCLE</kwd>
+        <kwd>ELEMENT</kwd>
     </kwdchoice>
-    <var></var>
    </keyin>
   </syntaxdiagram>
+      
+      <p>A <xmlelement>keyin</xmlelement> element using a required <xmlelement>kwdchoice</xmlelement> element:</p>   
+      <syntaxdiagram>
+          <keyin><kwdchoice>
+              <kwd>MOVE</kwd>
+              <kwd>MODIFY</kwd>
+          </kwdchoice>
+              <kwd>FENCE</kwd>
+          </keyin>
+      </syntaxdiagram>
+      
+      <p>A <xmlelement>keyin</xmlelement> element with a <xmlelement>var</xmlelement> element:</p>   
+      <syntaxdiagram>
+          <keyin>
+              <kwd>FENCE</kwd>
+              <kwd>FILE</kwd>
+              <var>filename</var>
+          </keyin>
+      </syntaxdiagram>
   </section>
   <section>
    <title>SVG</title>

--- a/samples/dtd/m-map.xml
+++ b/samples/dtd/m-map.xml
@@ -5,6 +5,7 @@
  <topicmeta>
   <author>Jason Coleman</author>
  </topicmeta>
+ <topicref href="base_topic.dita" format="dita" navtitle="Base Topic"/>
  <topicref href="c-concept.xml" format="dita" navtitle="Concept"/>
  <topicref href="f-faq.xml" format="dita" navtitle="FAQ"/>
  <topicref href="r-reference.xml" format="dita" navtitle="Reference"/>

--- a/samples/dtd/r-reference.xml
+++ b/samples/dtd/r-reference.xml
@@ -16,61 +16,177 @@
    <title>Highlighting Domain</title>
    <p>Now <em>this</em> is some emphasis.</p>
   </section>
-  <section>
-   <title>Math &amp; Equation Domain</title>   
-   <p>A legacy inline equation: <mathph>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></mathph></p>
-   <p>A legacy block equation:</p>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <p>A legacy equation block:</p>
-   <equation>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <eqsymbols>
-    <eqsymbol>
-     <symname>A</symname>
-     <symdesc>Long side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>B</symname>
-     <symdesc>Short side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>C</symname>
-     <symdesc>Hypotenuse of triangle</symdesc>
-    </eqsymbol>
-   </eqsymbols>
-   </equation>
-   <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
-   <p>A legacy inline equation with MathML content: <mathph><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"
-			 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
-				<mml:msup> <mml:mi>a</mml:mi> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:msup> <mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math></mathph></p>
-  <equation-block id="equation-block_p2c_xxd_cjb">
-   <mathml>
-    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-				<mml:msup> <mml:mi>a</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:msup>
-				<mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi> <mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math>
-   </mathml>
-  </equation-block>
-  </section>
+    <section id="section_yrq_5wl_d1c">
+      <title>UI Domain</title>
+      <p>Press <kbd>Enter</kbd>.</p>
+    </section>
+    <section id="section_of4_swl_d1c">
+      <title>Equation and Math Domains</title>
+      <p>An <xmlelement>equation-inline</xmlelement> element with text content:
+            <equation-inline>A<sup>2</sup> + B<sup>2</sup> = C<sup>2</sup></equation-inline></p>
+      <p>An <xmlelement>equation-figure</xmlelement> element with text content:</p>
+      <equation-figure id="equation-figure_pf4_swl_d1c">
+        <equation-block id="equation-block_qf4_swl_d1c">A<sup>2</sup> + B<sup>2</sup> =
+            C<sup>2</sup></equation-block>
+        <dl id="dl_rf4_swl_d1c">
+          <dlentry>
+            <dt>A</dt>
+            <dd>Long side of triangle</dd>
+          </dlentry>
+          <dlentry>
+            <dt>B</dt>
+            <dd>Short side of triangle</dd>
+          </dlentry>
+          <dlentry>
+            <dt>C</dt>
+            <dd>Hypotenuse of triangle</dd>
+          </dlentry>
+        </dl>
+      </equation-figure>
+      <p>An <xmlelement>equation-inline</xmlelement> with MathML content: <equation-inline><mathml>
+            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+              id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
+              <m:msup>
+                <m:mi>a</m:mi>
+                <m:mn>2</m:mn>
+              </m:msup>
+              <m:msup>
+                <m:mrow>
+                  <m:mo>+</m:mo>
+                  <m:mi>b</m:mi>
+                </m:mrow>
+                <m:mn>2</m:mn>
+              </m:msup>
+              <m:mo>=</m:mo>
+              <m:msup>
+                <m:mi>c</m:mi>
+                <m:mn>2</m:mn>
+              </m:msup>
+            </m:math>
+          </mathml></equation-inline></p>
+      <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+          <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+      <equation-block id="equation-block_sf4_swl_d1c">
+        <mathml>
+          <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true">
+            <m:mi>x</m:mi>
+            <m:mo>=</m:mo>
+            <m:mfrac>
+              <m:mrow>
+                <m:mo>-</m:mo>
+                <m:mi>b</m:mi>
+                <m:mo>±</m:mo>
+                <m:msqrt>
+                  <m:msup>
+                    <m:mrow>
+                      <m:mi>b</m:mi>
+                    </m:mrow>
+                    <m:mrow>
+                      <m:mn>2</m:mn>
+                    </m:mrow>
+                  </m:msup>
+                  <m:mo>-</m:mo>
+                  <m:mn>4</m:mn>
+                  <m:mi>a</m:mi>
+                  <m:mi>c</m:mi>
+                </m:msqrt>
+              </m:mrow>
+              <m:mrow>
+                <m:mn>2</m:mn>
+                <m:mi>a</m:mi>
+              </m:mrow>
+            </m:mfrac>
+          </m:math>
+        </mathml>
+      </equation-block>
+      <p>An <xmlelement>equation-figure</xmlelement> containing MathML markup:</p>
+      <equation-figure id="equation-figure_tf4_swl_d1c">
+        <equation-block id="equation-block_p2c_xxd_cjb">
+          <mathml>
+            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+              id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
+              <m:msup>
+                <m:mi>a</m:mi>
+                <m:mn>2</m:mn>
+              </m:msup>
+              <m:msup>
+                <m:mrow>
+                  <m:mo>+</m:mo>
+                  <m:mi>b</m:mi>
+                </m:mrow>
+                <m:mn>2</m:mn>
+              </m:msup>
+              <m:mo>=</m:mo>
+              <m:msup>
+                <m:mi>c</m:mi>
+                <m:mn>2</m:mn>
+              </m:msup>
+            </m:math>
+          </mathml>
+        </equation-block>
+        <dl id="dl_uf4_swl_d1c">
+          <dlentry>
+            <dt><equation-inline><mathml>
+                  <m:math>
+                    <m:mi>A</m:mi>
+                  </m:math>
+                </mathml></equation-inline></dt>
+            <dd>Long side of triangle</dd>
+          </dlentry>
+          <dlentry>
+            <dt><equation-inline><mathml>
+                  <m:math>
+                    <m:mi>B</m:mi>
+                  </m:math>
+                </mathml></equation-inline></dt>
+            <dd>Short side of triangle</dd>
+          </dlentry>
+          <dlentry>
+            <dt><equation-inline><mathml>
+                  <m:math>
+                    <m:mi>C</m:mi>
+                  </m:math>
+                </mathml></equation-inline></dt>
+            <dd>Hypotenuse of triangle</dd>
+          </dlentry>
+        </dl>
+      </equation-figure>
+    </section>
     
     <refsyn>
       <title>Programming Domain</title>
-      <syntaxdiagram>
-        <keyin><kwd>terrainmodel</kwd><kwd>import</kwd><kwd>file</kwd></keyin>
+      <p>A <xmlelement>keyin</xmlelement> element using a optional
+          <xmlelement>kwdchoice</xmlelement> element:</p>
+      <syntaxdiagram id="syntaxdiagram_cv3_twl_d1c">
+        <keyin>
+          <kwd>PLACE</kwd>
+          <kwd>FENCE</kwd>
+          <kwdchoice>
+            <kwd>BLOCK</kwd>
+            <kwd>CIRCLE</kwd>
+            <kwd>ELEMENT</kwd>
+          </kwdchoice>
+        </keyin>
+      </syntaxdiagram>
+      <p>A <xmlelement>keyin</xmlelement> element using a required
+          <xmlelement>kwdchoice</xmlelement> element:</p>
+      <syntaxdiagram id="syntaxdiagram_dv3_twl_d1c">
+        <keyin>
+          <kwdchoice>
+            <kwd>MOVE</kwd>
+            <kwd>MODIFY</kwd>
+          </kwdchoice>
+          <kwd>FENCE</kwd>
+        </keyin>
+      </syntaxdiagram>
+      <p>A <xmlelement>keyin</xmlelement> element with a <xmlelement>var</xmlelement> element:</p>
+      <syntaxdiagram id="syntaxdiagram_ev3_twl_d1c">
+        <keyin>
+          <kwd>FENCE</kwd>
+          <kwd>FILE</kwd>
+          <var>filename</var>
+        </keyin>
       </syntaxdiagram>
     </refsyn>
-  <section>
-   <title>UI Domain</title>
-   <p>Press <kbd>Enter</kbd>.</p>
-  </section>
   </refbody>
 </reference>

--- a/samples/dtd/s-troubleshooting.xml
+++ b/samples/dtd/s-troubleshooting.xml
@@ -40,10 +40,41 @@
         <title>Solution 2</title> 
         <steps-informal>
           <p>A less formal method of describing a solution.</p>
-          <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
+          <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+              <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+          <equation-block id="equation-block_bxc_wwl_d1c">
+            <mathml>
+              <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true">
+                <m:mi>x</m:mi>
+                <m:mo>=</m:mo>
+                <m:mfrac>
+                  <m:mrow>
+                    <m:mo>-</m:mo>
+                    <m:mi>b</m:mi>
+                    <m:mo>±</m:mo>
+                    <m:msqrt>
+                      <m:msup>
+                        <m:mrow>
+                          <m:mi>b</m:mi>
+                        </m:mrow>
+                        <m:mrow>
+                          <m:mn>2</m:mn>
+                        </m:mrow>
+                      </m:msup>
+                      <m:mo>-</m:mo>
+                      <m:mn>4</m:mn>
+                      <m:mi>a</m:mi>
+                      <m:mi>c</m:mi>
+                    </m:msqrt>
+                  </m:mrow>
+                  <m:mrow>
+                    <m:mn>2</m:mn>
+                    <m:mi>a</m:mi>
+                  </m:mrow>
+                </m:mfrac>
+              </m:math>
+            </mathml>
+          </equation-block>
         </steps-informal>
       </remedy>
     </troubleSolution>

--- a/samples/dtd/t-task.xml
+++ b/samples/dtd/t-task.xml
@@ -49,10 +49,41 @@
             <step>
                 <cmd>Equation &amp; Math Domain:</cmd>
                 <info>
-                    <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
+                    <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup
+                        using the <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+                    <equation-block id="equation-block_akw_wwl_d1c">
+                        <mathml>
+                            <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true">
+                                <m:mi>x</m:mi>
+                                <m:mo>=</m:mo>
+                                <m:mfrac>
+                                    <m:mrow>
+                                        <m:mo>-</m:mo>
+                                        <m:mi>b</m:mi>
+                                        <m:mo>±</m:mo>
+                                        <m:msqrt>
+                                            <m:msup>
+                                                <m:mrow>
+                                                  <m:mi>b</m:mi>
+                                                </m:mrow>
+                                                <m:mrow>
+                                                  <m:mn>2</m:mn>
+                                                </m:mrow>
+                                            </m:msup>
+                                            <m:mo>-</m:mo>
+                                            <m:mn>4</m:mn>
+                                            <m:mi>a</m:mi>
+                                            <m:mi>c</m:mi>
+                                        </m:msqrt>
+                                    </m:mrow>
+                                    <m:mrow>
+                                        <m:mn>2</m:mn>
+                                        <m:mi>a</m:mi>
+                                    </m:mrow>
+                                </m:mfrac>
+                            </m:math>
+                        </mathml>
+                    </equation-block>
                 </info>
             </step>
             <step>

--- a/samples/dtd/v-verification.xml
+++ b/samples/dtd/v-verification.xml
@@ -35,51 +35,138 @@
    <title>Highlighting Domain</title>
    <p>Now <em>this</em> is some emphasis.</p>
   </section>
-  <section>
-   <title>Math &amp; Equation Domain</title>   
-   <p>A legacy inline equation: <mathph>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></mathph></p>
-   <p>A legacy block equation:</p>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <p>A legacy equation block:</p>
-   <equation>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <eqsymbols>
-    <eqsymbol>
-     <symname>A</symname>
-     <symdesc>Long side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>B</symname>
-     <symdesc>Short side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>C</symname>
-     <symdesc>Hypotenuse of triangle</symdesc>
-    </eqsymbol>
-   </eqsymbols>
-   </equation>
-   <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
-   <p>A legacy inline equation with MathML content: <mathph><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"
-			 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
-				<mml:msup> <mml:mi>a</mml:mi> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:msup> <mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math></mathph></p>
-  <equation-block id="equation-block_p2c_xxd_cjb">
-   <mathml>
-    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-				<mml:msup> <mml:mi>a</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:msup>
-				<mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi> <mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math>
-   </mathml>
-  </equation-block>
-  </section>
+   <section id="section_hlr_ywl_d1c">
+    <title>Equation and Math Domains</title>
+    <p>An <xmlelement>equation-inline</xmlelement> element with text content:
+       <equation-inline>A<sup>2</sup> + B<sup>2</sup> = C<sup>2</sup></equation-inline></p>
+    <p>An <xmlelement>equation-figure</xmlelement> element with text content:</p>
+    <equation-figure id="equation-figure_ilr_ywl_d1c">
+     <equation-block id="equation-block_jlr_ywl_d1c">A<sup>2</sup> + B<sup>2</sup> =
+      C<sup>2</sup></equation-block>
+     <dl id="dl_klr_ywl_d1c">
+      <dlentry>
+       <dt>A</dt>
+       <dd>Long side of triangle</dd>
+      </dlentry>
+      <dlentry>
+       <dt>B</dt>
+       <dd>Short side of triangle</dd>
+      </dlentry>
+      <dlentry>
+       <dt>C</dt>
+       <dd>Hypotenuse of triangle</dd>
+      </dlentry>
+     </dl>
+    </equation-figure>
+    <p>An <xmlelement>equation-inline</xmlelement> with MathML content: <equation-inline><mathml>
+       <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+        id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
+        <m:msup>
+         <m:mi>a</m:mi>
+         <m:mn>2</m:mn>
+        </m:msup>
+        <m:msup>
+         <m:mrow>
+          <m:mo>+</m:mo>
+          <m:mi>b</m:mi>
+         </m:mrow>
+         <m:mn>2</m:mn>
+        </m:msup>
+        <m:mo>=</m:mo>
+        <m:msup>
+         <m:mi>c</m:mi>
+         <m:mn>2</m:mn>
+        </m:msup>
+       </m:math>
+      </mathml></equation-inline></p>
+    <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+      <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+    <equation-block id="equation-block_llr_ywl_d1c">
+     <mathml>
+      <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true">
+       <m:mi>x</m:mi>
+       <m:mo>=</m:mo>
+       <m:mfrac>
+        <m:mrow>
+         <m:mo>-</m:mo>
+         <m:mi>b</m:mi>
+         <m:mo>±</m:mo>
+         <m:msqrt>
+          <m:msup>
+           <m:mrow>
+            <m:mi>b</m:mi>
+           </m:mrow>
+           <m:mrow>
+            <m:mn>2</m:mn>
+           </m:mrow>
+          </m:msup>
+          <m:mo>-</m:mo>
+          <m:mn>4</m:mn>
+          <m:mi>a</m:mi>
+          <m:mi>c</m:mi>
+         </m:msqrt>
+        </m:mrow>
+        <m:mrow>
+         <m:mn>2</m:mn>
+         <m:mi>a</m:mi>
+        </m:mrow>
+       </m:mfrac>
+      </m:math>
+     </mathml>
+    </equation-block>
+    <p>An <xmlelement>equation-figure</xmlelement> containing MathML markup:</p>
+    <equation-figure id="equation-figure_mlr_ywl_d1c">
+     <equation-block id="equation-block_p2c_xxd_cjb">
+      <mathml>
+       <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+        id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
+        <m:msup>
+         <m:mi>a</m:mi>
+         <m:mn>2</m:mn>
+        </m:msup>
+        <m:msup>
+         <m:mrow>
+          <m:mo>+</m:mo>
+          <m:mi>b</m:mi>
+         </m:mrow>
+         <m:mn>2</m:mn>
+        </m:msup>
+        <m:mo>=</m:mo>
+        <m:msup>
+         <m:mi>c</m:mi>
+         <m:mn>2</m:mn>
+        </m:msup>
+       </m:math>
+      </mathml>
+     </equation-block>
+     <dl id="dl_nlr_ywl_d1c">
+      <dlentry>
+       <dt><equation-inline><mathml>
+          <m:math>
+           <m:mi>A</m:mi>
+          </m:math>
+         </mathml></equation-inline></dt>
+       <dd>Long side of triangle</dd>
+      </dlentry>
+      <dlentry>
+       <dt><equation-inline><mathml>
+          <m:math>
+           <m:mi>B</m:mi>
+          </m:math>
+         </mathml></equation-inline></dt>
+       <dd>Short side of triangle</dd>
+      </dlentry>
+      <dlentry>
+       <dt><equation-inline><mathml>
+          <m:math>
+           <m:mi>C</m:mi>
+          </m:math>
+         </mathml></equation-inline></dt>
+       <dd>Hypotenuse of triangle</dd>
+      </dlentry>
+     </dl>
+    </equation-figure>
+   </section>
   <section>
    <title>Programming Domain</title>
   <syntaxdiagram>
@@ -102,7 +189,7 @@
   <comparison>
    <title>Comparison</title>
    <table id="TABLE_136FD118620A49689E15B5E2F1BBF4D6">
-    <title id="GUID-4DD71DC8-7547-493B-B4EF-519A453801FB"></title>
+    <title id="GUID-4DD71DC8-7547-493B-B4EF-519A453801FB">Comparison of values</title>
     <tgroup cols="4">
      <thead>
       <row>

--- a/samples/project-files/html5_dtd.xml
+++ b/samples/project-files/html5_dtd.xml
@@ -3,9 +3,6 @@
 <project xmlns="https://www.dita-ot.org/project">
   <context name="Sample Bentley DTD Topics" id="html">
     <input href="../dtd/m-map.xml"/>
-    <!--<profile>
-      <ditaval href="../../resources/html.ditaval"/>
-    </profile>-->
   </context>
   <deliverable name="HTML5" id="html">
     <context idref="html"/>

--- a/samples/project-files/html5_rng.xml
+++ b/samples/project-files/html5_rng.xml
@@ -3,9 +3,6 @@
 <project xmlns="https://www.dita-ot.org/project">
   <context name="Sample Bentley DTD Topics" id="html">
     <input href="../rng/m-map.xml"/>
-    <!--<profile>
-      <ditaval href="../../resources/html.ditaval"/>
-    </profile>-->
   </context>
   <deliverable name="HTML5" id="html">
     <context idref="html"/>

--- a/samples/project-files/html5_xsd.xml
+++ b/samples/project-files/html5_xsd.xml
@@ -3,9 +3,6 @@
 <project xmlns="https://www.dita-ot.org/project">
   <context name="Sample Bentley DTD Topics" id="html">
     <input href="../schema/m-map.xml"/>
-    <!--<profile>
-      <ditaval href="../../resources/html.ditaval"/>
-    </profile>-->
   </context>
   <deliverable name="HTML5" id="html">
     <context idref="html"/>

--- a/samples/rng/base_topic.dita
+++ b/samples/rng/base_topic.dita
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model name="urn:bentley:names:tc:dita:rng:topic.rng" schematypens="https://relaxng.org/ns/structure/1.0?>
+<topic id="base_topic">
+    <title>Base Topic</title>
+    <shortdesc>This topic uses the Bentley Topic DocType.</shortdesc>
+    <body>
+        <section>
+            <title>Highlighting Domain</title>
+            
+            <p>Now <em>this</em> is some emphasis!</p>
+            
+        </section>
+        <section>
+            <title>UI Domain</title>
+            <p>Press <kbd>Ctrl+O</kbd> to open a new document.</p>
+        </section>
+        <section id="section_ljy_s5l_d1c">
+            <title>Programming Domain</title>
+            <syntaxdiagram id="syntaxdiagram_mjy_s5l_d1c">
+                <keyin>
+                    <kwd>Place Fence</kwd>
+                    <kwdchoice>
+                        <kwd>Block</kwd>
+                        <kwd>Circle</kwd>
+                    </kwdchoice>
+                </keyin>
+            </syntaxdiagram>
+        </section>
+    </body>
+</topic>

--- a/samples/rng/c-concept.xml
+++ b/samples/rng/c-concept.xml
@@ -15,68 +15,124 @@
    <title>Highlighting Domain</title>
    <p>Now <em>this</em> is some emphasis.</p>
   </section>
-  <section>
-   <title>Math &amp; Equation Domain</title>   
-   <p>A legacy inline equation: <mathph>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></mathph></p>
-   <p>A legacy block equation:</p>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <p>A legacy equation block:</p>
-   <equation>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <eqsymbols>
-    <eqsymbol>
-     <symname>A</symname>
-     <symdesc>Long side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>B</symname>
-     <symdesc>Short side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>C</symname>
-     <symdesc>Hypotenuse of triangle</symdesc>
-    </eqsymbol>
-   </eqsymbols>
-   </equation>
-   <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
-   <p>A legacy inline equation with MathML content: <mathph><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"
-			 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
-				<mml:msup> <mml:mi>a</mml:mi> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:msup> <mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math></mathph></p>
-  <equation-block id="equation-block_p2c_xxd_cjb">
-   <mathml>
-    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-				<mml:msup> <mml:mi>a</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:msup>
-				<mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi> <mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math>
-   </mathml>
-  </equation-block>
-  </section>
-  <section>
-   <title>Programming Domain</title>
-  <syntaxdiagram>
-   <keyin>
-     <kwd>KWD</kwd>
-     <kwdchoice>
-      <kwd>KWD1</kwd>
-      <kwd>KWD2</kwd>
-     </kwdchoice>
-     <var>var</var>
-    </keyin>
-  </syntaxdiagram>
-  </section>
-  <section>
-   <title>UI Domain</title>
-   <p>Press <kbd>Enter</kbd>.</p>
-  </section>
+     <section>
+         <title>UI Domain</title>
+         <p>Press <kbd>Enter</kbd>.</p>
+     </section>
+     <section>
+         <title>Equation and Math Domains</title>
+         
+         <p>An <xmlelement>equation-inline</xmlelement> element with text content:
+             <equation-inline>A<sup>2</sup> + B<sup>2</sup> =
+                 C<sup>2</sup></equation-inline></p>
+         <p>An <xmlelement>equation-figure</xmlelement> element with text content:</p>
+         <equation-figure>
+             <equation-block>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></equation-block>
+             <dl>
+                 <dlentry>
+                     <dt>A</dt>
+                     <dd>Long side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt>B</dt>
+                     <dd>Short side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt>C</dt>
+                     <dd>Hypotenuse of triangle</dd>
+                 </dlentry>
+             </dl>
+         </equation-figure>
+         
+         <p>An  <xmlelement>equation-inline</xmlelement> with MathML content: <equation-inline><mathml>
+             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+                 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
+                 <m:msup>
+                     <m:mi>a</m:mi>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+                 <m:msup>
+                     <m:mrow>
+                         <m:mo>+</m:mo>
+                         <m:mi>b</m:mi>
+                     </m:mrow>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+                 <m:mo>=</m:mo>
+                 <m:msup>
+                     <m:mi>c</m:mi>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+             </m:math>
+         </mathml></equation-inline></p>
+         <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+             <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+         
+         <equation-block>
+             <mathml>
+                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true"><m:mi>x</m:mi><m:mo>=</m:mo><m:mfrac><m:mrow><m:mo>-</m:mo><m:mi>b</m:mi><m:mo>±</m:mo><m:msqrt><m:msup><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo>-</m:mo><m:mn>4</m:mn><m:mi>a</m:mi><m:mi>c</m:mi></m:msqrt></m:mrow><m:mrow><m:mn>2</m:mn><m:mi>a</m:mi></m:mrow></m:mfrac></m:math>    
+             </mathml>
+         </equation-block>
+         <p>An <xmlelement>equation-figure</xmlelement> containing MathML markup:</p>
+         <equation-figure>
+             <equation-block id="equation-block_p2c_xxd_cjb">
+                 <mathml>
+                     <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
+                         <m:msup> <m:mi>a</m:mi>
+                             <m:mn>2</m:mn> </m:msup> <m:msup>
+                                 <m:mrow> <m:mo>+</m:mo> <m:mi>b</m:mi> </m:mrow> <m:mn>2</m:mn> </m:msup>
+                         <m:mo>=</m:mo> <m:msup> <m:mi>c</m:mi> <m:mn>2</m:mn> </m:msup> 
+                     </m:math>
+                 </mathml>
+             </equation-block>
+             <dl>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>A</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Long side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>B</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Short side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>C</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Hypotenuse of triangle</dd>
+                 </dlentry>
+             </dl>
+         </equation-figure>
+     </section>
+     <section>
+         <title>Programming Domain</title>
+         <p>A <xmlelement>keyin</xmlelement> element using a optional <xmlelement>kwdchoice</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin>
+                 <kwd>PLACE</kwd> <kwd>FENCE</kwd><kwdchoice>
+                     <kwd>BLOCK</kwd>
+                     <kwd>CIRCLE</kwd>
+                     <kwd>ELEMENT</kwd>
+                 </kwdchoice>
+             </keyin>
+         </syntaxdiagram>
+         
+         <p>A <xmlelement>keyin</xmlelement> element using a required <xmlelement>kwdchoice</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin><kwdchoice>
+                 <kwd>MOVE</kwd>
+                 <kwd>MODIFY</kwd>
+             </kwdchoice>
+                 <kwd>FENCE</kwd>
+             </keyin>
+         </syntaxdiagram>
+         
+         <p>A <xmlelement>keyin</xmlelement> element with a <xmlelement>var</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin>
+                 <kwd>FENCE</kwd>
+                 <kwd>FILE</kwd>
+                 <var>filename</var>
+             </keyin>
+         </syntaxdiagram>
+     </section>
   <section>
    <title>SVG</title>
    <fig>

--- a/samples/rng/m-map.xml
+++ b/samples/rng/m-map.xml
@@ -5,6 +5,7 @@
  <topicmeta>
   <author>Jason Coleman</author>
  </topicmeta>
+ <topicref href="base_topic.dita" format="dita" navtitle="Base Topic"/>
  <topicref href="c-concept.xml" format="dita" navtitle="Concept"/>
  <topicref href="f-faq.xml" format="dita" navtitle="FAQ"/>
  <topicref href="r-reference.xml" format="dita" navtitle="Reference"/>

--- a/samples/schema/base_topic.dita
+++ b/samples/schema/base_topic.dita
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model name="urn:bentley:names:tc:dita:xsd:topic.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<topic id="base_topic">
+    <title>Base Topic</title>
+    <shortdesc>This topic uses the Bentley Topic DocType.</shortdesc>
+    <body>
+        <section>
+            <title>Highlighting Domain</title>
+            
+            <p>Now <em>this</em> is some emphasis!</p>
+            
+        </section>
+        <section>
+            <title>UI Domain</title>
+            <p>Press <kbd>Ctrl+O</kbd> to open a new document.</p>
+        </section>
+        <section id="section_ljy_s5l_d1c">
+            <title>Programming Domain</title>
+            <syntaxdiagram id="syntaxdiagram_mjy_s5l_d1c">
+                <keyin>
+                    <kwd>Place Fence</kwd>
+                    <kwdchoice>
+                        <kwd>Block</kwd>
+                        <kwd>Circle</kwd>
+                    </kwdchoice>
+                </keyin>
+            </syntaxdiagram>
+        </section>
+    </body>
+</topic>

--- a/samples/schema/c-concept.xml
+++ b/samples/schema/c-concept.xml
@@ -15,68 +15,124 @@
    <title>Highlighting Domain</title>
    <p>Now <em>this</em> is some emphasis.</p>
   </section>
-  <section>
-   <title>Math &amp; Equation Domain</title>   
-   <p>A legacy inline equation: <mathph>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></mathph></p>
-   <p>A legacy block equation:</p>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <p>A legacy equation block:</p>
-   <equation>
-   <math>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></math>
-   <eqsymbols>
-    <eqsymbol>
-     <symname>A</symname>
-     <symdesc>Long side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>B</symname>
-     <symdesc>Short side of triangle</symdesc>
-    </eqsymbol>
-    <eqsymbol>
-     <symname>C</symname>
-     <symdesc>Hypotenuse of triangle</symdesc>
-    </eqsymbol>
-   </eqsymbols>
-   </equation>
-   <p>A legacy block equation with MathML content:</p>
-   <math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-     <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mfrac><mml:mrow><mml:mo>-</mml:mo><mml:mi>b</mml:mi><mml:mo>±</mml:mo><mml:msqrt><mml:msup><mml:mrow><mml:mi>b</mml:mi></mml:mrow><mml:mrow><mml:mn>2</mml:mn></mml:mrow></mml:msup><mml:mo>-</mml:mo><mml:mn>4</mml:mn><mml:mi>a</mml:mi><mml:mi>c</mml:mi></mml:msqrt></mml:mrow><mml:mrow><mml:mn>2</mml:mn><mml:mi>a</mml:mi></mml:mrow></mml:mfrac></mml:math>    
-   </math>
-   <p>A legacy inline equation with MathML content: <mathph><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML"
-			 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
-				<mml:msup> <mml:mi>a</mml:mi> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:msup> <mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math></mathph></p>
-  <equation-block id="equation-block_p2c_xxd_cjb">
-   <mathml>
-    <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML">
-				<mml:msup> <mml:mi>a</mml:mi>
-				<mml:mn>2</mml:mn> </mml:msup> <mml:msup>
-				<mml:mrow> <mml:mo>+</mml:mo> <mml:mi>b</mml:mi> </mml:mrow> <mml:mn>2</mml:mn> </mml:msup>
-				<mml:mo>=</mml:mo> <mml:msup> <mml:mi>c</mml:mi> <mml:mn>2</mml:mn> </mml:msup> 
-			 </mml:math>
-   </mathml>
-  </equation-block>
-  </section>
-  <section>
-   <title>Programming Domain</title>
-  <syntaxdiagram>
-   <keyin>
-     <kwd>KWD</kwd>
-     <kwdchoice>
-      <kwd>KWD1</kwd>
-      <kwd>KWD2</kwd>
-     </kwdchoice>
-     <var>var</var>
-    </keyin>
-  </syntaxdiagram>
-  </section>
-  <section>
-   <title>UI Domain</title>
-   <p>Press <kbd>Enter</kbd>.</p>
-  </section>
+     <section>
+         <title>UI Domain</title>
+         <p>Press <kbd>Enter</kbd>.</p>
+     </section>
+     <section>
+         <title>Equation and Math Domains</title>
+         
+         <p>An <xmlelement>equation-inline</xmlelement> element with text content:
+             <equation-inline>A<sup>2</sup> + B<sup>2</sup> =
+                 C<sup>2</sup></equation-inline></p>
+         <p>An <xmlelement>equation-figure</xmlelement> element with text content:</p>
+         <equation-figure>
+             <equation-block>A<sup>2</sup> + B<sup>2</sup> =  C<sup>2</sup></equation-block>
+             <dl>
+                 <dlentry>
+                     <dt>A</dt>
+                     <dd>Long side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt>B</dt>
+                     <dd>Short side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt>C</dt>
+                     <dd>Hypotenuse of triangle</dd>
+                 </dlentry>
+             </dl>
+         </equation-figure>
+         
+         <p>An  <xmlelement>equation-inline</xmlelement> with MathML content: <equation-inline><mathml>
+             <m:math xmlns:m="http://www.w3.org/1998/Math/MathML"
+                 id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF1">
+                 <m:msup>
+                     <m:mi>a</m:mi>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+                 <m:msup>
+                     <m:mrow>
+                         <m:mo>+</m:mo>
+                         <m:mi>b</m:mi>
+                     </m:mrow>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+                 <m:mo>=</m:mo>
+                 <m:msup>
+                     <m:mi>c</m:mi>
+                     <m:mn>2</m:mn>
+                 </m:msup>
+             </m:math>
+         </mathml></equation-inline></p>
+         <p>An <xmlelement>equation-block</xmlelement> element containing MathML markup using the
+             <xmlatt>displayTrue</xmlatt>=<q>true</q>:</p>
+         
+         <equation-block>
+             <mathml>
+                 <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" displaystyle="true"><m:mi>x</m:mi><m:mo>=</m:mo><m:mfrac><m:mrow><m:mo>-</m:mo><m:mi>b</m:mi><m:mo>±</m:mo><m:msqrt><m:msup><m:mrow><m:mi>b</m:mi></m:mrow><m:mrow><m:mn>2</m:mn></m:mrow></m:msup><m:mo>-</m:mo><m:mn>4</m:mn><m:mi>a</m:mi><m:mi>c</m:mi></m:msqrt></m:mrow><m:mrow><m:mn>2</m:mn><m:mi>a</m:mi></m:mrow></m:mfrac></m:math>    
+             </mathml>
+         </equation-block>
+         <p>An <xmlelement>equation-figure</xmlelement> containing MathML markup:</p>
+         <equation-figure>
+             <equation-block id="equation-block_p2c_xxd_cjb">
+                 <mathml>
+                     <m:math xmlns:m="http://www.w3.org/1998/Math/MathML" id="GUID-8F13F947-884D-43D1-9F7F-4DF8CFFECCF2">
+                         <m:msup> <m:mi>a</m:mi>
+                             <m:mn>2</m:mn> </m:msup> <m:msup>
+                                 <m:mrow> <m:mo>+</m:mo> <m:mi>b</m:mi> </m:mrow> <m:mn>2</m:mn> </m:msup>
+                         <m:mo>=</m:mo> <m:msup> <m:mi>c</m:mi> <m:mn>2</m:mn> </m:msup> 
+                     </m:math>
+                 </mathml>
+             </equation-block>
+             <dl>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>A</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Long side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>B</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Short side of triangle</dd>
+                 </dlentry>
+                 <dlentry>
+                     <dt><equation-inline><mathml><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"><m:mi>C</m:mi></m:math></mathml></equation-inline></dt>
+                     <dd>Hypotenuse of triangle</dd>
+                 </dlentry>
+             </dl>
+         </equation-figure>
+     </section>
+     <section>
+         <title>Programming Domain</title>
+         <p>A <xmlelement>keyin</xmlelement> element using a optional <xmlelement>kwdchoice</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin>
+                 <kwd>PLACE</kwd> <kwd>FENCE</kwd><kwdchoice>
+                     <kwd>BLOCK</kwd>
+                     <kwd>CIRCLE</kwd>
+                     <kwd>ELEMENT</kwd>
+                 </kwdchoice>
+             </keyin>
+         </syntaxdiagram>
+         
+         <p>A <xmlelement>keyin</xmlelement> element using a required <xmlelement>kwdchoice</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin><kwdchoice>
+                 <kwd>MOVE</kwd>
+                 <kwd>MODIFY</kwd>
+             </kwdchoice>
+                 <kwd>FENCE</kwd>
+             </keyin>
+         </syntaxdiagram>
+         
+         <p>A <xmlelement>keyin</xmlelement> element with a <xmlelement>var</xmlelement> element:</p>   
+         <syntaxdiagram>
+             <keyin>
+                 <kwd>FENCE</kwd>
+                 <kwd>FILE</kwd>
+                 <var>filename</var>
+             </keyin>
+         </syntaxdiagram>
+     </section>
   <section>
    <title>SVG</title>
    <fig>

--- a/samples/schema/m-map.xml
+++ b/samples/schema/m-map.xml
@@ -5,6 +5,7 @@
  <topicmeta>
   <author>Jason Coleman</author>
  </topicmeta>
+ <topicref href="base_topic.dita" format="dita" navtitle="Base Topic"/>
  <topicref href="c-concept.xml" format="dita" navtitle="Concept"/>
  <topicref href="f-faq.xml" format="dita" navtitle="FAQ"/>
  <topicref href="r-reference.xml" format="dita" navtitle="Reference"/>

--- a/schema-url/technicalContent/catalog.xml
+++ b/schema-url/technicalContent/catalog.xml
@@ -8,30 +8,41 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 <!--DITA Abbreviated Form Domain-->
 
    <group><!-- System ID (URL) catalog entries -->
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd:1.3" 
+              uri="xsd/topic.xsd"/>
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd:1.x" 
+              uri="xsd/topic.xsd"/>
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd" 
+              uri="xsd/topic.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd:1.3"
               uri="xsd/concept.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd:1.x"
               uri="xsd/concept.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd"
               uri="xsd/concept.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.3"
               uri="xsd/generalTask.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.x"
               uri="xsd/generalTask.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd"
               uri="xsd/generalTask.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.3"
               uri="xsd/glossary.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.x"
               uri="xsd/glossary.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd"
               uri="xsd/glossary.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd:1.3"
               uri="xsd/glossentry.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd:1.x"
               uri="xsd/glossentry.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd"
               uri="xsd/glossentry.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossgroup.xsd:1.3"
               uri="xsd/glossgroup.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossgroup.xsd:1.x"
@@ -132,23 +143,33 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
                    uri="xsd/verificationMod.xsd"/>
    </group>
    <group><!-- Public ID (URN) catalog entries -->
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd:1.3" 
+           uri="xsd/topic.xsd"/>
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd:1.x" 
+           uri="xsd/topic.xsd"/>
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd" 
+           uri="xsd/topic.xsd"/>
+           
       <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd:1.3"
            uri="xsd/concept.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd:1.x"
            uri="xsd/concept.xsd"/>
-      <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd" uri="xsd/concept.xsd"/>
-      
+      <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd" 
+           uri="xsd/concept.xsd"/>
+           
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.3"
            uri="xsd/generalTask.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.x"
            uri="xsd/generalTask.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd"
            uri="xsd/generalTask.xsd"/>
+           
       <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.3"
            uri="xsd/glossary.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.x"
            uri="xsd/glossary.xsd"/>
-      <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd" uri="xsd/glossary.xsd"/>
+      <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd" 
+           uri="xsd/glossary.xsd"/>
            
       <uri name="urn:bentley:names:tc:dita:xsd:glossentry.xsd:1.3"
            uri="xsd/glossentry.xsd"/>

--- a/schema-url/technicalContent/xsd/topic.xsd
+++ b/schema-url/technicalContent/xsd/topic.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
+<!-- OASIS Standard                                           -->
+<!-- 16 January 2018                                           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- MODULE:    DITA Topic XSD                                     -->
+<!-- VERSION:   1.3                                                -->
+<!-- DATE:      March 2014                                         -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Darwin Information Typing Architecture (DITA)     -->
+<!--                                                               -->
+<!-- PURPOSE:    W3C XML Schema to describe DITA Topics            -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--            March 2001                                         -->
+<!--                                                               -->
+<!--    2024.01.18 JTC: Created shell for Bentley                  -->
+<!-- ============================================================= -->
+<xs:schema xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+<!-- ================ TOPIC DOMAINS ===================== -->
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/abbreviateDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/deliveryTargetAttDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/equationDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/hazardstatementDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/indexingDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/markupDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/mathmlDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/releaseManagementDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/softwareDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/svgDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/utilitiesDomain.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/technicalContent/xsd/xmlDomain.xsd"/>
+   
+   <!-- JTC: Use BENTLEY entities for specialized domains -->  
+   <xs:include schemaLocation="../../base/xsd/highlightDomain.xsd"/>
+   <xs:include schemaLocation="./programmingDomain.xsd"/>
+   <xs:include schemaLocation="./uiDomain.xsd"/>
+
+   <!-- ================ GROUP DEFINITIONS ===================== -->
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclGrp.xsd"/>
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/topicGrp.xsd"/>
+
+   <!-- =================  MODULE INCLUDE DEFINITION  ================== -->
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/commonElementMod.xsd"/>
+
+   <!-- ======== Table elements ======== -->
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/tblDeclMod.xsd"/>
+
+   <!-- ======= MetaData elements, plus keyword and indexterm ======= -->
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/metaDeclMod.xsd"/>
+
+   <xs:redefine schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/commonElementGrp.xsd">
+      <xs:group name="data">
+         <xs:choice>
+            <xs:group ref="data"/>
+            <xs:group ref="ut-d-data"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="foreign">
+         <xs:choice>
+            <xs:group ref="foreign"/>
+            <xs:group ref="mathml-d-foreign"/>
+            <xs:group ref="svg-d-foreign"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="note">
+         <xs:choice>
+            <xs:group ref="note"/>
+            <xs:group ref="hazard-d-note"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="dl">
+         <xs:choice>
+            <xs:group ref="dl"/>
+            <xs:group ref="pr-d-dl"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="fig">
+         <xs:choice>
+            <xs:group ref="fig"/>
+            <xs:group ref="equation-d-fig"/>
+            <xs:group ref="pr-d-fig"/>
+            <xs:group ref="ut-d-fig"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="pre">
+         <xs:choice>
+            <xs:group ref="pre"/>
+            <xs:group ref="pr-d-pre"/>
+            <xs:group ref="sw-d-pre"/>
+            <xs:group ref="ui-d-pre"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="div">
+         <xs:choice>
+            <xs:group ref="div"/>
+            <xs:group ref="equation-d-div"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="keyword">
+         <xs:choice>
+            <xs:group ref="keyword"/>
+            <xs:group ref="markup-d-keyword"/>
+            <xs:group ref="pr-d-keyword"/>
+            <xs:group ref="sw-d-keyword"/>
+            <xs:group ref="ui-d-keyword"/>
+            <xs:group ref="xml-d-keyword"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="term">
+         <xs:choice>
+            <xs:group ref="term"/>
+            <xs:group ref="abbrev-d-term"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="ph">
+         <xs:choice>
+            <xs:group ref="ph"/>
+            <xs:group ref="equation-d-ph"/>
+            <xs:group ref="hi-d-ph"/>
+            <xs:group ref="pr-d-ph"/>
+            <xs:group ref="sw-d-ph"/>
+            <xs:group ref="ui-d-ph"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="index-base">
+         <xs:choice>
+            <xs:group ref="index-base"/>
+            <xs:group ref="indexing-d-index-base"/>
+         </xs:choice>
+      </xs:group>
+      
+      <!-- 2019-09-17 JTC: Added Bentley domain specializations -->
+      <xs:group name="figgroup">
+         <xs:choice>
+            <xs:group ref="figgroup"/>
+            <xs:group ref="pr-d-figgroup"/>
+         </xs:choice>
+      </xs:group>
+      
+      <xs:attributeGroup name="props-attribute-extensions">
+         <xs:attributeGroup ref="props-attribute-extensions"/>
+         <xs:attributeGroup ref="deliveryTargetAtt-d-attribute"/>
+      </xs:attributeGroup>
+   </xs:redefine>
+   <xs:redefine schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/metaDeclGrp.xsd">
+      <xs:group name="metadata">
+         <xs:choice>
+            <xs:group ref="metadata"/>
+            <xs:group ref="relmgmt-d-metadata"/>
+         </xs:choice>
+      </xs:group>
+   </xs:redefine>
+
+
+   <xs:include schemaLocation="../../../../org.oasis-open.dita.v1_3/schema-url/base/xsd/topicMod.xsd"/>
+   <!--  ================ INFO-TYPES DEFINITION =====================  -->
+   <xs:group name="info-types">
+      <xs:annotation>
+         <xs:documentation>
+This group is referenced in all topic modules but not defined there.
+It must be declared in topic-type shells.
+</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:element ref="no-topic-nesting" maxOccurs="0" minOccurs="0"/>
+      </xs:choice>
+   </xs:group>
+
+   <xs:attributeGroup name="domains-att">
+      <xs:attribute name="domains"
+                    type="xs:string"
+                    default="(topic abbrev-d) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d xml-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic svg-d) (topic sw-d) (topic ui-d) (topic ut-d) a(props deliveryTarget)"/>
+   </xs:attributeGroup>
+</xs:schema>

--- a/schema/technicalContent/catalog.xml
+++ b/schema/technicalContent/catalog.xml
@@ -8,30 +8,41 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 <!--DITA Abbreviated Form Domain-->
 
    <group><!-- System ID (URL) catalog entries -->
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd:1.3" 
+              uri="xsd/topic.xsd"/>
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd:1.x" 
+              uri="xsd/topic.xsd"/>
+      <system systemId="urn:bentley:names:tc:dita:xsd:topic.xsd" 
+              uri="xsd/topic.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd:1.3"
               uri="xsd/concept.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd:1.x"
               uri="xsd/concept.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:concept.xsd"
               uri="xsd/concept.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.3"
               uri="xsd/generalTask.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.x"
               uri="xsd/generalTask.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:generalTask.xsd"
               uri="xsd/generalTask.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.3"
               uri="xsd/glossary.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.x"
               uri="xsd/glossary.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossary.xsd"
               uri="xsd/glossary.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd:1.3"
               uri="xsd/glossentry.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd:1.x"
               uri="xsd/glossentry.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossentry.xsd"
               uri="xsd/glossentry.xsd"/>
+           
       <system systemId="urn:bentley:names:tc:dita:xsd:glossgroup.xsd:1.3"
               uri="xsd/glossgroup.xsd"/>
       <system systemId="urn:bentley:names:tc:dita:xsd:glossgroup.xsd:1.x"
@@ -132,18 +143,27 @@ Copyright (c) Bentley Systems, Incorporated. All rights reserved.
                    uri="xsd/verificationMod.xsd"/>
    </group>
    <group><!-- Public ID (URN) catalog entries -->
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd:1.3" 
+           uri="xsd/topic.xsd"/>
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd:1.x" 
+           uri="xsd/topic.xsd"/>
+      <uri name="urn:bentley:names:tc:dita:xsd:topic.xsd" 
+           uri="xsd/topic.xsd"/>
+           
       <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd:1.3"
            uri="xsd/concept.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd:1.x"
            uri="xsd/concept.xsd"/>
-      <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd" uri="xsd/concept.xsd"/>
-      
+      <uri name="urn:bentley:names:tc:dita:xsd:concept.xsd" 
+           uri="xsd/concept.xsd"/>
+
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.3"
            uri="xsd/generalTask.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd:1.x"
            uri="xsd/generalTask.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:generalTask.xsd"
            uri="xsd/generalTask.xsd"/>
+           
       <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.3"
            uri="xsd/glossary.xsd"/>
       <uri name="urn:bentley:names:tc:dita:xsd:glossary.xsd:1.x"

--- a/schema/technicalContent/xsd/topic.xsd
+++ b/schema/technicalContent/xsd/topic.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ============================================================= -->
+<!--                    HEADER                                     -->
+<!-- ============================================================= -->
+<!-- Darwin Information Typing Architecture (DITA) Version 1.3 Plus Errata 02     -->
+<!-- OASIS Standard                                           -->
+<!-- 16 January 2018                                           -->
+<!-- Copyright (c) OASIS Open 2018. All rights reserved.           -->
+<!-- Source: http://docs.oasis-open.org/dita/dita/v1.3/errata02/csprd01/complete/part0-overview/dita-v1.3-errata02-csprd01-part0-overview-complete.html                                -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- MODULE:    DITA Topic XSD                                     -->
+<!-- VERSION:   1.3                                                -->
+<!-- DATE:      March 2014                                         -->
+<!--                                                               -->
+<!-- ============================================================= -->
+<!-- ============================================================= -->
+<!-- SYSTEM:     Darwin Information Typing Architecture (DITA)     -->
+<!--                                                               -->
+<!-- PURPOSE:    W3C XML Schema to describe DITA Topics            -->
+<!--                                                               -->
+<!-- ORIGINAL CREATION DATE:                                       -->
+<!--            March 2001                                         -->
+<!--                                                               -->
+<!--    2024.01.18 JTC: Created shell for Bentley                  -->
+<!-- ============================================================= -->
+<xs:schema xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+<!-- ================ TOPIC DOMAINS ===================== -->
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:abbreviateDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:deliveryTargetAttDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:equationDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:hazardDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:indexingDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:markupDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:mathmlDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:releaseManagementDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:softwareDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:svgDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:utilitiesDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:xmlDomain.xsd:1.3"/>
+   
+   <!-- JTC: Use BENTLEY entities for specialized domains -->   
+   <xs:include schemaLocation="urn:bentley:names:tc:dita:xsd:highlightDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:bentley:names:tc:dita:xsd:programmingDomain.xsd:1.3"/>
+   <xs:include schemaLocation="urn:bentley:names:tc:dita:xsd:uiDomain.xsd:1.3"/> 
+
+   <!-- ================ GROUP DEFINITIONS ===================== -->
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:tblDeclGrp.xsd:1.3"/>
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:topicGrp.xsd:1.3"/>
+
+   <!-- =================  MODULE INCLUDE DEFINITION  ================== -->
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:commonElementMod.xsd:1.3"/>
+
+   <!-- ======== Table elements ======== -->
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:tblDeclMod.xsd:1.3"/>
+
+   <!-- ======= MetaData elements, plus keyword and indexterm ======= -->
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:metaDeclMod.xsd:1.3"/>
+
+   <xs:redefine schemaLocation="urn:oasis:names:tc:dita:xsd:commonElementGrp.xsd:1.3">
+      <xs:group name="data">
+         <xs:choice>
+            <xs:group ref="data"/>
+            <xs:group ref="ut-d-data"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="foreign">
+         <xs:choice>
+            <xs:group ref="foreign"/>
+            <xs:group ref="mathml-d-foreign"/>
+            <xs:group ref="svg-d-foreign"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="note">
+         <xs:choice>
+            <xs:group ref="note"/>
+            <xs:group ref="hazard-d-note"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="dl">
+         <xs:choice>
+            <xs:group ref="dl"/>
+            <xs:group ref="pr-d-dl"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="fig">
+         <xs:choice>
+            <xs:group ref="fig"/>
+            <xs:group ref="equation-d-fig"/>
+            <xs:group ref="pr-d-fig"/>
+            <xs:group ref="ut-d-fig"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="pre">
+         <xs:choice>
+            <xs:group ref="pre"/>
+            <xs:group ref="pr-d-pre"/>
+            <xs:group ref="sw-d-pre"/>
+            <xs:group ref="ui-d-pre"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="div">
+         <xs:choice>
+            <xs:group ref="div"/>
+            <xs:group ref="equation-d-div"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="keyword">
+         <xs:choice>
+            <xs:group ref="keyword"/>
+            <xs:group ref="markup-d-keyword"/>
+            <xs:group ref="pr-d-keyword"/>
+            <xs:group ref="sw-d-keyword"/>
+            <xs:group ref="ui-d-keyword"/>
+            <xs:group ref="xml-d-keyword"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="term">
+         <xs:choice>
+            <xs:group ref="term"/>
+            <xs:group ref="abbrev-d-term"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="ph">
+         <xs:choice>
+            <xs:group ref="ph"/>
+            <xs:group ref="equation-d-ph"/>
+            <xs:group ref="hi-d-ph"/>
+            <xs:group ref="pr-d-ph"/>
+            <xs:group ref="sw-d-ph"/>
+            <xs:group ref="ui-d-ph"/>
+         </xs:choice>
+      </xs:group>
+      <xs:group name="index-base">
+         <xs:choice>
+            <xs:group ref="index-base"/>
+            <xs:group ref="indexing-d-index-base"/>
+         </xs:choice>
+      </xs:group>
+      
+      <!-- 2019-09-17 JTC: Added Bentley domain specializations -->
+      <xs:group name="figgroup">
+         <xs:choice>
+            <xs:group ref="figgroup"/>
+            <xs:group ref="pr-d-figgroup"/>
+         </xs:choice>
+      </xs:group>
+      
+      <xs:attributeGroup name="props-attribute-extensions">
+         <xs:attributeGroup ref="props-attribute-extensions"/>
+         <xs:attributeGroup ref="deliveryTargetAtt-d-attribute"/>
+      </xs:attributeGroup>
+   </xs:redefine>
+   <xs:redefine schemaLocation="urn:oasis:names:tc:dita:xsd:metaDeclGrp.xsd:1.3">
+      <xs:group name="metadata">
+         <xs:choice>
+            <xs:group ref="metadata"/>
+            <xs:group ref="relmgmt-d-metadata"/>
+         </xs:choice>
+      </xs:group>
+   </xs:redefine>
+
+
+   <xs:include schemaLocation="urn:oasis:names:tc:dita:xsd:topicMod.xsd:1.3"/>
+   <!--  ================ INFO-TYPES DEFINITION =====================  -->
+   <xs:group name="info-types">
+      <xs:annotation>
+         <xs:documentation>
+This group is referenced in all topic modules but not defined there.
+It must be declared in topic-type shells.
+</xs:documentation>
+      </xs:annotation>
+      <xs:choice>
+         <xs:element ref="no-topic-nesting" maxOccurs="0" minOccurs="0"/>
+      </xs:choice>
+   </xs:group>
+
+   <xs:attributeGroup name="domains-att">
+      <xs:attribute name="domains"
+                    type="xs:string"
+                    default="(topic abbrev-d) (topic equation-d) (topic hazard-d) (topic hi-d) (topic indexing-d) (topic markup-d xml-d) (topic markup-d) (topic mathml-d) (topic pr-d) (topic relmgmt-d) (topic svg-d) (topic sw-d) (topic ui-d) (topic ut-d) a(props deliveryTarget)"/>
+   </xs:attributeGroup>
+</xs:schema>


### PR DESCRIPTION
Two commits to add the base Topic type (topic.dtd) to the Bentley shells for DITA v1.3. 

This isn't expected to be used often, but it can cause conversion issues when validating using the catalog resolver if present.